### PR TITLE
Add facebook.com/messages support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ If you want the latest version, you can git clone the repo and install it as an 
 5) Go to messenger.com and click on a thread you want to delete. Click the extension, hit remove, and hopefully things happen.
 
 # How to Use
-1) Go to messenger.com
+1) Go to messenger.com **or** facebook.com/messages
 2) Open the messenger chain that you want to delete
 3) Click the extension and hit remove messages
 4) Leave the tab running. If you want to keep using the web on your computer, open a new browser.
 5) If you start getting hit with rate limiting by Facebook (generally an error, 'Cannot unsend at this time'), increase the `Rate limit pause` time in the Extension popup. The default is 5 seconds.
+
+### facebook.com/messages support
+
+Starting April 2026, Meta is redirecting `messenger.com` traffic to `facebook.com/messages`. Shoot the Messenger now works on both domains. If you are using a group chat and are a **group admin**, the extension will also attempt to remove messages sent by other participants.
 
 ### Misc notes.
 

--- a/main.js
+++ b/main.js
@@ -38,9 +38,8 @@ REMOVE_BUTTON_QUERY =
 OKAY_BUTTON_QUERY = '[aria-label="Okay"]';
 
 COULDNT_REMOVE_QUERY = '._3quh._30yy._2t_._5ixy.layerCancel';
-REMOVE_CONFIRMATION_QUERY = '[aria-label="Unsend"],[aria-label="Remove"]';
-CANCEL_CONFIRMATION_QUERY =
-  '[aria-label="Who do you want to unsend this message for?"] :not([aria-disabled="true"])[aria-label="Cancel"]';
+REMOVE_CONFIRMATION_QUERY = '[aria-label="Unsend"]:not([aria-disabled="true"]),[aria-label="Remove"]:not([aria-disabled="true"])';
+CANCEL_CONFIRMATION_QUERY = '[aria-label="Cancel"]:not([aria-disabled="true"])';
 
 // The loading animation.
 LOADING_QUERY = '[role="main"] svg[aria-valuetext="Loading..."]';
@@ -100,22 +99,52 @@ function getScroller() {
 
   let el;
   try {
-    // Try the new role-based selectors first, then legacy class-based ones.
-    el =
-      document.querySelector(MESSAGE_ROW_QUERY) ??
-      document.querySelector(MESSAGE_ROW_FALLBACK_QUERY) ??
-      document.querySelector(MY_ROW_QUERY) ??
-      getUnsentMessages()[0];
-    // Walk up the DOM tree to find the scrollable container.
-    // Use scrollHeight > clientHeight instead of scrollTop === 0 because
-    // scrollTop can be 0 when the user hasn't scrolled yet.
-    while (
-      !('scrollTop' in el) ||
-      el.scrollHeight <= el.clientHeight
-    ) {
-      console.log('Traversing tree to find scroller...', el);
-      el = el.parentElement;
+    // Primary: walk DOWN from [role="grid"] through first-children looking for
+    // the first element that is actually configured to scroll (overflow-y:
+    // auto|scroll) and has overflow content. The Messenger scroll container is
+    // a grandchild of the grid and this approach works even when message rows
+    // are virtualized (absent from the DOM).
+    const grid =
+      document.querySelector('[role="main"] [role="grid"]') ??
+      document.querySelector('[role="grid"]');
+    if (grid) {
+      let cur = grid.firstElementChild;
+      while (cur) {
+        const ov = window.getComputedStyle(cur).overflowY;
+        if (
+          (ov === 'auto' || ov === 'scroll') &&
+          cur.scrollHeight > cur.clientHeight
+        ) {
+          el = cur;
+          break;
+        }
+        cur = cur.firstElementChild;
+      }
     }
+
+    // Fallback: walk UP from any message row that happens to be rendered.
+    if (!el) {
+      let cur =
+        document.querySelector('[role="row"]') ??
+        document.querySelector(MESSAGE_ROW_QUERY) ??
+        document.querySelector(MESSAGE_ROW_FALLBACK_QUERY) ??
+        document.querySelector(MY_ROW_QUERY) ??
+        getUnsentMessages()[0];
+      while (cur) {
+        const ov = window.getComputedStyle(cur).overflowY;
+        if (
+          (ov === 'auto' || ov === 'scroll') &&
+          cur.scrollHeight > cur.clientHeight
+        ) {
+          el = cur;
+          break;
+        }
+        console.log('Traversing tree to find scroller...', cur);
+        cur = cur.parentElement;
+      }
+    }
+
+    if (!el) throw new Error('No scrollable parent found');
   } catch (e) {
     alert(
       'Could not find scroller. This normally happens because you do not ' +
@@ -165,16 +194,22 @@ async function prepareDOMForRemoval() {
 }
 
 async function getAllMessages() {
-  // Get all ... buttons that let you select 'more' for all messages you sent.
-  // Note: getUnsentMessages() is intentionally excluded here — "You unsent a
-  // message" placeholders are system notifications that cannot be unsent again
-  // and would cause infinite retry loops (#136). They are still used in
-  // getScroller() for scroll-parent detection.
-  // Prefer role-based selectors; fall back to legacy class-based ones.
-  let elementsToUnsend = [
-    ...document.querySelectorAll(MESSAGE_ROW_QUERY),
-    ...document.querySelectorAll(MESSAGE_ROW_FALLBACK_QUERY),
-  ];
+  // Use [role="row"]:has([data-scope="messages_table"]) to capture ALL actual
+  // message rows — both the current user's and other participants'. This lets
+  // group-chat admins remove anyone's messages. Date-separator rows and other
+  // non-message rows don't contain [data-scope="messages_table"] so they are
+  // excluded. Role-based and legacy class-based selectors are kept as fallbacks.
+  // Note: getUnsentMessages() is intentionally excluded — "You unsent a message"
+  // placeholders cannot be unsent again and would cause infinite retry loops (#136).
+  const allRows = document.querySelectorAll(
+    '[role="row"]:has([data-scope="messages_table"])',
+  );
+  let elementsToUnsend = allRows.length
+    ? [...allRows]
+    : [
+        ...document.querySelectorAll(MESSAGE_ROW_QUERY),
+        ...document.querySelectorAll(MESSAGE_ROW_FALLBACK_QUERY),
+      ];
   if (elementsToUnsend.length === 0) {
     elementsToUnsend = [...document.querySelectorAll(MY_ROW_QUERY)];
   }
@@ -240,7 +275,13 @@ async function unsendAllVisibleMessages() {
     await sleep(500);
     const removeButton = document.querySelectorAll(REMOVE_BUTTON_QUERY)[0];
     if (!removeButton) {
+      // Close the open More menu before skipping, otherwise it stays open and
+      // blocks interaction with the next message.
       console.log('No removeButton found! Skipping holder: ', el);
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      );
+      await sleep(200);
       continue;
     }
 
@@ -260,7 +301,7 @@ async function unsendAllVisibleMessages() {
         'Skipping unsend because we are in debug mode.',
         unsendButton,
       );
-      cancelButton.click();
+      cancelButton?.click();
     } else if (!unsendButton) {
       console.log('No unsendButton found! Skipping holder: ', el);
       if (cancelButton) {
@@ -375,6 +416,11 @@ async function removeHandler() {
   DELAY = localStorage.getItem(delayKey) ?? DELAY;
   console.log('Sleeping to allow the page to load fully...');
   await sleep(10000); // give the page a bit to fully load.
+
+  // Scroll to the bottom first so we always start from the newest message.
+  const scroller = getScroller();
+  scroller.scrollTop = scroller.scrollHeight;
+  await sleep(2000);
 
   const status = await deleteAllRunner(RUNNER_COUNT);
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
   "content_scripts": [
     {
-      "matches": ["http://*.messenger.com/*", "https://*.messenger.com/*"],
+      "matches": ["http://*.messenger.com/*", "https://*.messenger.com/*", "http://*.facebook.com/messages/*", "https://*.facebook.com/messages/*"],
       "js": ["main.js"],
       "run_at": "document_end"
     }
@@ -32,7 +32,9 @@
   "permissions": ["activeTab", "storage"],
   "host_permissions": [
     "http://*.messenger.com/*",
-    "https://*.messenger.com/*"
+    "https://*.messenger.com/*",
+    "http://*.facebook.com/messages/*",
+    "https://*.facebook.com/messages/*"
   ],
   "icons": { "128": "icon.png" },
 

--- a/popup.js
+++ b/popup.js
@@ -22,12 +22,16 @@ chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
   });
 });
 
-// Make sure the user is using messenger.com.
+// Make sure the user is using messenger.com or facebook.com/messages.
 const messengers = [
   'https://www.messenger.com',
   'http://www.messenger.com',
   'https://messenger.com/',
   'http://messenger.com/',
+  'https://www.facebook.com/messages',
+  'http://www.facebook.com/messages',
+  'https://facebook.com/messages',
+  'http://facebook.com/messages',
 ];
 chrome.tabs.query(
   {


### PR DESCRIPTION
## Summary

- Adds `facebook.com/messages` to the extension allow-list (`popup.js`) and manifest (`manifest.json`) so the popup works on the new Meta-hosted URL
- Fixes `getScroller()` to walk down from `[role="grid"]` using CSS `overflow-y` detection — works for group chats and virtualized message lists
- Fixes confirmation dialog selectors to skip disabled placeholder buttons (`:not([aria-disabled="true"])`)
- Switches to `[role="row"]:has([data-scope="messages_table"])` to process all message types including group chat messages (admins can remove others' messages)
- Scrolls to newest messages first so deletion runs latest → oldest
- Dispatches `Escape` to close the More menu when no Remove button is available
- Updates README to document facebook.com/messages support and group admin behavior

Closes #141

## Test plan

- [ ] Load unpacked extension in Chrome
- [ ] Open a conversation at `facebook.com/messages/…` — confirm popup shows "Remove Messages" (no domain error)
- [ ] Run removal on `facebook.com/messages` — confirm messages are deleted latest → oldest
- [ ] Verify `messenger.com` still works (regression)
- [ ] Verify group chat admin can remove others' messages